### PR TITLE
Bump ABI_VERSION

### DIFF
--- a/src/comp.c
+++ b/src/comp.c
@@ -472,7 +472,7 @@ load_gccjit_if_necessary (bool mandatory)
 
 
 /* Increase this number to force a new Vcomp_abi_hash to be generated.  */
-#define ABI_VERSION "7"
+#define ABI_VERSION "8"
 
 /* Length of the hashes used for eln file naming.  */
 #define HASH_LENGTH 8


### PR DESCRIPTION
Hi @kiennq ,
I'm really sorry about this, but my last patch was submitted with one crucial line missing: as the ABI for nativecomp modules changed, we need to bump the `ABI_VERSION` define.

This will prevent segfaults when non-MPS and MPS builds of the same Emacs version are mixed.

Sorry again,
Pip